### PR TITLE
chore: remove Renovate bot configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
## Summary
- Remove `renovate.json` to stop automated dependency update PRs from Renovate bot

## Test plan
- [x] Verify `renovate.json` is deleted